### PR TITLE
feat(modules): Register AltitudeLossDetector module

### DIFF
--- a/src/main/java/com/baseminer/basefinder/BaseFinder.java
+++ b/src/main/java/com/baseminer/basefinder/BaseFinder.java
@@ -5,6 +5,7 @@ import com.baseminer.basefinder.commands.BaseFinderCommand;
 import com.baseminer.basefinder.commands.ClearBasesCommand;
 import com.baseminer.basefinder.commands.ClearPlayersCommand;
 import com.baseminer.basefinder.hud.BaseFinderHud;
+import com.baseminer.basefinder.modules.AltitudeLossDetector;
 import com.baseminer.basefinder.modules.BaseFinderModule;
 import com.baseminer.basefinder.modules.StuckDetector;
 import com.mojang.logging.LogUtils;
@@ -32,6 +33,7 @@ public class BaseFinder extends MeteorAddon {
         // Modules
         Modules.get().add(new BaseFinderModule());
         Modules.get().add(new StuckDetector());
+        Modules.get().add(new AltitudeLossDetector());
 
         // Commands
         Commands.add(new BaseFinderCommand());


### PR DESCRIPTION
The AltitudeLossDetector module was not being registered with the Meteor Client's module system, so it was not appearing in the in-game GUI.

This commit adds the necessary code to register the module in the `BaseFinder` addon's `onInitialize` method.