### PR TITLE
Fix: Prevent natural structure detection from spamming chat

### DIFF
--- a/src/main/java/com/baseminer/basefinder/modules/BaseFinderModule.java
+++ b/src/main/java/com/baseminer/basefinder/modules/BaseFinderModule.java
@@ -492,9 +492,6 @@ public class BaseFinderModule extends Module {
 
         // Enhanced filtering for natural structures
         if (isNaturalStructure(cluster, volume, density)) {
-            info("Skipped natural structure at " + basePos.toShortString() +
-                 " (volume: " + String.format("%.0f", volume) +
-                 ", density: " + String.format("%.6f", density) + ")");
             return;
         }
 


### PR DESCRIPTION
Removes the `info` log message that was being printed to the chat every time a natural structure was detected and skipped. This was causing a lot of spam in the chat, making it difficult to read other important messages.

The message was purely for debugging purposes and is not necessary for the user to see. This change makes the mod less noisy and improves the user experience.