### PR TITLE
feat: Add pause and resume functionality to StashHunter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ repositories {
         name = "Fabric"
         url = uri("https://maven.fabricmc.net/")
     }
+    mavenCentral()
 }
 
 dependencies {
@@ -32,6 +33,9 @@ dependencies {
 
     // Meteor
     modImplementation("meteordevelopment:meteor-client:${properties["minecraft_version"] as String}-SNAPSHOT")
+
+    // GSON
+    implementation("com.google.code.gson:gson:2.10.1")
 }
 
 tasks {

--- a/src/main/java/com/stashhunter/stashhunter/commands/StashHunterCommand.java
+++ b/src/main/java/com/stashhunter/stashhunter/commands/StashHunterCommand.java
@@ -2,6 +2,7 @@ package com.stashhunter.stashhunter.commands;
 
 import com.stashhunter.stashhunter.utils.ElytraController;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import meteordevelopment.meteorclient.commands.Command;
@@ -70,6 +71,55 @@ public class StashHunterCommand extends Command {
             })
         );
 
+        // Pause scanning
+        builder.then(literal("pause")
+            .executes(context -> {
+                if (ElytraController.isActive()) {
+                    ElytraController.pause();
+                    info("Stash hunter flight paused.");
+                } else {
+                    error("Stash hunter is not currently active.");
+                }
+                return SINGLE_SUCCESS;
+            })
+        );
+
+        // Resume scanning
+        builder.then(literal("resume")
+            .executes(context -> {
+                if (ElytraController.isActive()) {
+                    error("Stash hunter is already active.");
+                } else {
+                    ElytraController.resume();
+                    info("Stash hunter flight resumed.");
+                }
+                return SINGLE_SUCCESS;
+            })
+            .then(argument("timestamp", LongArgumentType.longArg())
+                .executes(context -> {
+                    if (ElytraController.isActive()) {
+                        error("Stash hunter is already active.");
+                    } else {
+                        long timestamp = LongArgumentType.getLong(context, "timestamp");
+                        ElytraController.resume(timestamp);
+                        info("Stash hunter flight resumed.");
+                    }
+                    return SINGLE_SUCCESS;
+                })
+            )
+        );
+
+        // List trips
+        builder.then(literal("list")
+            .executes(context -> {
+                info("Saved trips:");
+                for (com.stashhunter.stashhunter.utils.TripManager.TripData trip : com.stashhunter.stashhunter.utils.TripManager.getTrips()) {
+                    info("  " + trip.timestamp);
+                }
+                return SINGLE_SUCCESS;
+            })
+        );
+
         // Status command
         builder.then(literal("status")
             .executes(context -> {
@@ -95,6 +145,9 @@ public class StashHunterCommand extends Command {
                 info("Stash-Hunter Commands:");
                 info("§7/stashhunter start <x1> <z1> <x2> <z2> [stripWidth] §f- Start scanning an area");
                 info("§7/stashhunter stop §f- Stop the current scanning operation");
+                info("§7/stashhunter pause §f- Pause the current scanning operation");
+                info("§7/stashhunter resume [timestamp] §f- Resume the latest or a specific trip");
+                info("§7/stashhunter list §f- List all saved trips");
                 info("§7/stashhunter status §f- Show current status and progress");
                 info("§7/stashhunter help §f- Show this help message");
                 info("");

--- a/src/main/java/com/stashhunter/stashhunter/utils/TripManager.java
+++ b/src/main/java/com/stashhunter/stashhunter/utils/TripManager.java
@@ -1,0 +1,78 @@
+package com.stashhunter.stashhunter.utils;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import meteordevelopment.meteorclient.MeteorClient;
+import net.minecraft.util.math.Vec3d;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class TripManager {
+    private static final File TRIPS_FILE = new File(MeteorClient.FOLDER, "stashhunter_trips.json");
+    private static final Gson GSON = new GsonBuilder()
+        .registerTypeAdapter(Vec3d.class, new Vec3dAdapter())
+        .setPrettyPrinting()
+        .create();
+
+    public static void saveTrips(List<TripData> trips) {
+        try (FileWriter writer = new FileWriter(TRIPS_FILE)) {
+            GSON.toJson(trips, writer);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static List<TripData> loadTrips() {
+        if (TRIPS_FILE.exists()) {
+            try (FileReader reader = new FileReader(TRIPS_FILE)) {
+                Type type = new TypeToken<List<TripData>>() {}.getType();
+                List<TripData> trips = GSON.fromJson(reader, type);
+                if (trips != null) {
+                    return trips;
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return new ArrayList<>();
+    }
+
+    public static void addTrip(List<Vec3d> waypoints, int currentWaypoint) {
+        List<TripData> trips = loadTrips();
+        trips.add(new TripData(System.currentTimeMillis(), waypoints, currentWaypoint));
+        saveTrips(trips);
+    }
+
+    public static List<TripData> getTrips() {
+        return loadTrips();
+    }
+
+    public static TripData getLatestTrip() {
+        return loadTrips().stream().max(Comparator.comparingLong(t -> t.timestamp)).orElse(null);
+    }
+
+    public static TripData getTrip(long timestamp) {
+        return loadTrips().stream().filter(t -> t.timestamp == timestamp).findFirst().orElse(null);
+    }
+
+
+    public static class TripData {
+        public final long timestamp;
+        public final List<Vec3d> waypoints;
+        public final int currentWaypoint;
+
+        public TripData(long timestamp, List<Vec3d> waypoints, int currentWaypoint) {
+            this.timestamp = timestamp;
+            this.waypoints = waypoints;
+            this.currentWaypoint = currentWaypoint;
+        }
+    }
+}

--- a/src/main/java/com/stashhunter/stashhunter/utils/Vec3dAdapter.java
+++ b/src/main/java/com/stashhunter/stashhunter/utils/Vec3dAdapter.java
@@ -1,0 +1,40 @@
+package com.stashhunter.stashhunter.utils;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import net.minecraft.util.math.Vec3d;
+
+import java.io.IOException;
+
+public class Vec3dAdapter extends TypeAdapter<Vec3d> {
+    @Override
+    public void write(JsonWriter out, Vec3d value) throws IOException {
+        out.beginObject();
+        out.name("x").value(value.x);
+        out.name("y").value(value.y);
+        out.name("z").value(value.z);
+        out.endObject();
+    }
+
+    @Override
+    public Vec3d read(JsonReader in) throws IOException {
+        in.beginObject();
+        double x = 0, y = 0, z = 0;
+        while (in.hasNext()) {
+            switch (in.nextName()) {
+                case "x":
+                    x = in.nextDouble();
+                    break;
+                case "y":
+                    y = in.nextDouble();
+                    break;
+                case "z":
+                    z = in.nextDouble();
+                    break;
+            }
+        }
+        in.endObject();
+        return new Vec3d(x, y, z);
+    }
+}


### PR DESCRIPTION
Adds the ability to pause and resume stash hunting trips. Trips are saved to a file, allowing them to be resumed across game sessions.

New commands:
- `.stashhunter pause`: Pauses the current trip and saves it to a file.
- `.stashhunter resume [timestamp]`: Resumes the latest trip, or a specific trip if a timestamp is provided.
- `.stashhunter list`: Lists all saved trips with their timestamps.

Includes:
- A `TripManager` to handle saving and loading trip data.
- A custom GSON `TypeAdapter` for `Vec3d` objects.
- Refactoring of `ElytraController` to reduce code duplication.