### PR TITLE
Fix a crash caused by a Mixin accessor failing to find its target field.

### DIFF
--- a/src/main/java/com/stashhunter/stashhunter/mixin/PlayerInventoryAccessor.java
+++ b/src/main/java/com/stashhunter/stashhunter/mixin/PlayerInventoryAccessor.java
@@ -6,6 +6,6 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(PlayerInventory.class)
 public interface PlayerInventoryAccessor {
-    @Accessor("selectedSlot")
+    @Accessor
     void setSelectedSlot(int slot);
 }


### PR DESCRIPTION
The `PlayerInventoryAccessor` mixin was using an explicit field name in the `@Accessor` annotation, which caused a runtime error after a Minecraft update.

By removing the explicit field name, the Mixin framework can now correctly infer the target field from the accessor method's name, making the code more robust and resilient to future updates.